### PR TITLE
Add Docker multi-stage build and GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: piwero/ravenous
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ravenous
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ravenous/.dockerignore
+++ b/ravenous/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+build
+.git
+.gitignore
+README.md

--- a/ravenous/Dockerfile
+++ b/ravenous/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: Build the React app
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve with Nginx
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/ravenous/nginx.conf
+++ b/ravenous/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:css|js|jpg|jpeg|png|gif|ico|svg|woff2?|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
This pull request introduces Docker support for the `ravenous` project, enabling automated building and publishing of Docker images to GitHub Container Registry. The changes include a multi-stage Dockerfile for building and serving the React app with Nginx, a tailored Nginx configuration, a `.dockerignore` file to optimize the build context, and a GitHub Actions workflow for CI/CD automation.

**Dockerization and Deployment Automation:**

* Added a multi-stage `Dockerfile` in `ravenous/` to build the React app using Node.js and serve it with Nginx for production deployment.
* Introduced a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, improving build efficiency.
* Created an Nginx configuration (`nginx.conf`) optimized for serving a single-page React app, including cache control for static assets.

**CI/CD Integration:**

* Added a GitHub Actions workflow (`.github/workflows/docker-publish.yaml`) to automatically build and push Docker images to GitHub Container Registry on new version tags. on v* tags, pushes to ghcr.io/piwero/ravenous